### PR TITLE
feat: add Tavily web search provider alongside existing providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ SERPER_API_KEY=
 # https://brave.com/search/api/
 BRAVE_API_KEY=
 
+# Tavily Search API (free tier: 1000 credits/month)
+# https://app.tavily.com
+TAVILY_API_KEY=
+
 # GitHub personal access token (raises rate limit from 60 to 5000 req/hour)
 GITHUB_TOKEN=
 

--- a/=0.5.0
+++ b/=0.5.0
@@ -1,0 +1,4 @@
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+
+[notice] A new release of pip is available: 24.0 -> 26.0.1
+[notice] To update, run: pip install --upgrade pip

--- a/=0.5.0
+++ b/=0.5.0
@@ -1,4 +1,0 @@
-WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
-
-[notice] A new release of pip is available: 24.0 -> 26.0.1
-[notice] To update, run: pip install --upgrade pip

--- a/metasearchmcp/config.py
+++ b/metasearchmcp/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
 
     # API keys — web providers
     brave_api_key: str = ""
+    tavily_api_key: str = ""
 
     # API keys — developer providers
     github_token: str = ""

--- a/metasearchmcp/providers/registry.py
+++ b/metasearchmcp/providers/registry.py
@@ -20,6 +20,7 @@ from .baidu import BaiduProvider
 
 # Web search — API
 from .brave import BraveProvider
+from .tavily import TavilyProvider
 
 # Knowledge / reference
 from .wikipedia import WikipediaProvider
@@ -56,6 +57,7 @@ _ALL_PROVIDER_CLASSES: list[type[BaseProvider]] = [
     BingProvider,
     YahooProvider,
     BraveProvider,
+    TavilyProvider,
     EcosiaProvider,
     MojeekProvider,
     StartpageProvider,

--- a/metasearchmcp/providers/tavily.py
+++ b/metasearchmcp/providers/tavily.py
@@ -20,18 +20,22 @@ class TavilyProvider(BaseProvider):
     def __init__(self) -> None:
         super().__init__()
         self._api_key = get_settings().tavily_api_key
+        self._tavily: AsyncTavilyClient | None = None
         if self._api_key:
-            self._client = AsyncTavilyClient(api_key=self._api_key)
+            self._tavily = AsyncTavilyClient(api_key=self._api_key)
 
     def is_available(self) -> bool:
         return bool(self._api_key)
 
     async def search(self, query: str, params: SearchParams) -> ProviderResult:
+        if self._tavily is None:
+            raise RuntimeError("TavilyProvider: no API key configured")
+
         max_results = min(params.num_results, self._max_results, 20)
 
         # Note: Tavily's search API does not support language, country, or
         # safe_search filtering. These SearchParams fields are silently ignored.
-        response = await self._client.search(
+        response = await self._tavily.search(
             query=query,
             max_results=max_results,
             search_depth="basic",

--- a/metasearchmcp/providers/tavily.py
+++ b/metasearchmcp/providers/tavily.py
@@ -20,15 +20,18 @@ class TavilyProvider(BaseProvider):
     def __init__(self) -> None:
         super().__init__()
         self._api_key = get_settings().tavily_api_key
+        if self._api_key:
+            self._client = AsyncTavilyClient(api_key=self._api_key)
 
     def is_available(self) -> bool:
         return bool(self._api_key)
 
     async def search(self, query: str, params: SearchParams) -> ProviderResult:
-        client = AsyncTavilyClient(api_key=self._api_key)
         max_results = min(params.num_results, self._max_results, 20)
 
-        response = await client.search(
+        # Note: Tavily's search API does not support language, country, or
+        # safe_search filtering. These SearchParams fields are silently ignored.
+        response = await self._client.search(
             query=query,
             max_results=max_results,
             search_depth="basic",

--- a/metasearchmcp/providers/tavily.py
+++ b/metasearchmcp/providers/tavily.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from tavily import AsyncTavilyClient
+
+from metasearchmcp.config import get_settings
+from metasearchmcp.contracts import ProviderResult, SearchParams, SearchResult
+from .base import BaseProvider
+
+
+class TavilyProvider(BaseProvider):
+    """Tavily Search via the official Python SDK.
+
+    Free tier: 1000 API credits/month. API key required.
+    Sign up at https://app.tavily.com
+    """
+
+    name = "tavily"
+    tags = ["web"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._api_key = get_settings().tavily_api_key
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    async def search(self, query: str, params: SearchParams) -> ProviderResult:
+        client = AsyncTavilyClient(api_key=self._api_key)
+        max_results = min(params.num_results, self._max_results, 20)
+
+        response = await client.search(
+            query=query,
+            max_results=max_results,
+            search_depth="basic",
+        )
+
+        return self._parse(response)
+
+    def _parse(self, data: dict) -> ProviderResult:
+        results: list[SearchResult] = []
+
+        for i, item in enumerate(data.get("results", []), start=1):
+            results.append(SearchResult(
+                title=item.get("title", ""),
+                url=item.get("url", ""),
+                snippet=item.get("content", ""),
+                rank=i,
+                provider=self.name,
+                published_date=item.get("published_date"),
+            ))
+
+        return ProviderResult(results=results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "lxml>=5.2.0",
     "mcp>=1.0.0",
     "python-dotenv>=1.0.0",
+    "tavily-python>=0.5.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Added Tavily as a new web search provider using the `tavily-python` SDK
- Follows the existing `BaseProvider` plugin architecture (same pattern as `BraveProvider`)
- Auto-enables when `TAVILY_API_KEY` environment variable is set
- Discoverable via the `web` tag alongside DuckDuckGo and Brave

## Files changed

- **`metasearchmcp/providers/tavily.py`** (new) — `TavilyProvider` subclass using `AsyncTavilyClient`, gated on API key availability
- **`metasearchmcp/providers/registry.py`** — imported and registered `TavilyProvider` after `BraveProvider`
- **`metasearchmcp/config.py`** — added `tavily_api_key: str = ""` setting
- **`pyproject.toml`** — added `tavily-python>=0.5.0` to dependencies
- **`.env.example`** — added `TAVILY_API_KEY=` entry with signup URL

## Dependency changes

- Added `tavily-python>=0.5.0` to `pyproject.toml` dependencies

## Environment variable changes

- Added `TAVILY_API_KEY` (optional — provider auto-enables when set)

## Notes for reviewers

- This is an **additive** change — no existing providers are modified or removed
- The provider uses `search_depth="basic"` for cost efficiency (1 credit per query)
- Existing aggregator, orchestrator, broker, and MCP server code require no changes


### Automated Review

- Passed after 3 attempt(s)
- Final review: The Tavily provider migration is correct and complete. The implementation follows the existing provider pattern closely (mirrors BraveProvider structure), fixes both issues from prior review rounds (renamed `_client` → `_tavily` to avoid shadowing `BaseProvider._client()`, and unconditionally initializes `_tavily = None` with a `RuntimeError` guard in `search()`). All five files are properly updated: `tavily.py`, `config.py`, `registry.py`, `.env.example`, and `pyproject.toml`. No regressions to existing providers. One minor issue: the `AsyncTavilyClient` is constructed without a timeout, so `settings.default_timeout` is not honored for Tavily calls.
