### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ SERPER_API_KEY=
 # https://brave.com/search/api/
 BRAVE_API_KEY=
 
+# You.com Search API (free tier available)
+# https://you.com/platform
+YDC_API_KEY=
+
 # GitHub personal access token (raises rate limit from 60 to 5000 req/hour)
 GITHUB_TOKEN=
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Provider priority for `/search/google` is now `google` first, then `google_serpb
 | Bing | `bing` | RSS feed |
 | Yahoo | `yahoo` | HTML scraping, best effort |
 | Brave | `brave` | Official Search API |
+| You.com | `youcom` | Official Search API |
 | Mwmbl | `mwmbl` | Public JSON API |
 | Ecosia | `ecosia` | HTML scraping |
 | Mojeek | `mojeek` | HTML scraping |
@@ -170,6 +171,7 @@ AGGREGATOR_TIMEOUT=15
 SERPBASE_API_KEY=
 SERPER_API_KEY=
 BRAVE_API_KEY=
+YDC_API_KEY=
 GITHUB_TOKEN=
 STACKEXCHANGE_API_KEY=
 REDDIT_CLIENT_ID=
@@ -182,6 +184,18 @@ FINNHUB_API_KEY=
 ENABLED_PROVIDERS=
 ALLOW_UNSTABLE_PROVIDERS=false
 MAX_RESULTS_PER_PROVIDER=10
+```
+
+To enable You.com, set `YDC_API_KEY` and either let it participate in the default web-provider pool or explicitly target it with `providers: ["youcom"]`.
+
+```bash
+curl -X POST http://localhost:8000/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "playwright locator best practices",
+    "providers": ["youcom"],
+    "params": {"num_results": 5}
+  }'
 ```
 
 ## Running

--- a/metasearchmcp/config.py
+++ b/metasearchmcp/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
 
     # API keys — web providers
     brave_api_key: str = ""
+    ydc_api_key: str = ""
 
     # API keys — developer providers
     github_token: str = ""

--- a/metasearchmcp/providers/registry.py
+++ b/metasearchmcp/providers/registry.py
@@ -16,8 +16,6 @@ from .arxiv import ArxivProvider
 from .baidu import BaiduProvider
 from .bing import BingProvider
 from .brave import BraveProvider
-
-# Developer
 from .crates import CratesIoProvider
 from .crossref import CrossrefProvider
 from .dockerhub import DockerHubProvider
@@ -55,6 +53,7 @@ from .wikipedia import WikipediaProvider
 from .yahoo import YahooProvider
 from .yahoo_finance import YahooFinanceProvider
 from .yandex import YandexProvider
+from .youcom import YouComProvider
 
 if TYPE_CHECKING:
     from .base import BaseProvider
@@ -71,6 +70,7 @@ _ALL_PROVIDER_CLASSES: list[type[BaseProvider]] = [
     BingProvider,
     YahooProvider,
     BraveProvider,
+    YouComProvider,
     MwmblProvider,
     EcosiaProvider,
     MojeekProvider,

--- a/metasearchmcp/providers/youcom.py
+++ b/metasearchmcp/providers/youcom.py
@@ -1,0 +1,84 @@
+"""You.com Search API provider."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from metasearchmcp.config import get_settings
+from metasearchmcp.contracts import ProviderResult, SearchParams, SearchResult
+
+from .base import BaseProvider
+
+_API_URL = "https://ydc-index.io/v1/search"
+
+
+class YouComProvider(BaseProvider):
+    """You.com web search provider.
+
+    API key optional for the Search API free tier. Configure ``YDC_API_KEY`` to
+    send authenticated requests.
+    """
+
+    name = "youcom"
+    description = "You.com web search API with optional citations and news results."
+    tags: ClassVar[list[str]] = ["web"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._api_key = get_settings().ydc_api_key
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    async def search(self, query: str, params: SearchParams) -> ProviderResult:
+        qp = {
+            "query": query,
+            "count": str(min(params.num_results, self._max_results)),
+        }
+        if not params.safe_search:
+            qp["safesearch"] = "off"
+        headers = {
+            "Accept": "application/json",
+            "X-API-Key": self._api_key,
+        }
+        async with self._client() as client:
+            resp = await client.get(_API_URL, params=qp, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return self._parse(data)
+
+    def _parse(self, data: dict) -> ProviderResult:
+        results: list[SearchResult] = []
+        sections = [
+            data.get("results", {}).get("web", []),
+            data.get("results", {}).get("news", []),
+        ]
+        rank = 1
+        for items in sections:
+            for item in items:
+                url = item.get("url", "")
+                title = item.get("title", "")
+                snippet = item.get("description", "") or ""
+                if not snippet:
+                    snippets = item.get("snippets") or []
+                    if snippets:
+                        snippet = snippets[0]
+                results.append(
+                    SearchResult(
+                        title=title,
+                        url=url,
+                        snippet=snippet,
+                        rank=rank,
+                        provider=self.name,
+                        published_date=(item.get("page_age") or "")[0:10] or None,
+                        extra={
+                            "snippets": item.get("snippets", []),
+                            "thumbnail_url": item.get("thumbnail_url", ""),
+                            "favicon_url": item.get("favicon_url", ""),
+                        },
+                    ),
+                )
+                rank += 1
+                if len(results) >= self._max_results:
+                    return ProviderResult(results=results)
+        return ProviderResult(results=results)

--- a/tests/test_youcom_provider.py
+++ b/tests/test_youcom_provider.py
@@ -1,0 +1,89 @@
+"""Tests for the You.com provider."""
+
+from __future__ import annotations
+
+from metasearchmcp.config import get_settings
+
+
+def _youcom_response() -> dict:
+    return {
+        "results": {
+            "web": [
+                {
+                    "url": "https://example.com/guide",
+                    "title": "Example Guide",
+                    "description": "A practical guide.",
+                    "snippets": ["A practical guide snippet."],
+                    "page_age": "2026-07-01T12:30:00",
+                    "thumbnail_url": "https://example.com/thumb.png",
+                    "favicon_url": "https://example.com/favicon.ico",
+                }
+            ],
+            "news": [
+                {
+                    "url": "https://news.example.com/story",
+                    "title": "Example News",
+                    "description": "Latest story.",
+                    "page_age": "2026-07-02T09:00:00",
+                }
+            ],
+        }
+    }
+
+
+def test_youcom_parse_merges_web_and_news_results():
+    from metasearchmcp.providers.youcom import YouComProvider
+
+    provider = YouComProvider()
+    result = provider._parse(_youcom_response())
+
+    assert len(result.results) == 2
+    first = result.results[0]
+    assert first.title == "Example Guide"
+    assert first.url == "https://example.com/guide"
+    assert first.provider == "youcom"
+    assert first.published_date == "2026-07-01"
+    assert first.extra["thumbnail_url"] == "https://example.com/thumb.png"
+
+    second = result.results[1]
+    assert second.title == "Example News"
+    assert second.rank == 2
+    assert second.published_date == "2026-07-02"
+
+
+def test_youcom_parse_falls_back_to_first_snippet_when_description_missing():
+    from metasearchmcp.providers.youcom import YouComProvider
+
+    provider = YouComProvider()
+    result = provider._parse(
+        {
+            "results": {
+                "web": [
+                    {
+                        "url": "https://example.com",
+                        "title": "Example",
+                        "description": "",
+                        "snippets": ["Fallback snippet"],
+                    }
+                ]
+            }
+        },
+    )
+
+    assert result.results[0].snippet == "Fallback snippet"
+
+
+def test_youcom_availability_requires_api_key(monkeypatch):
+    get_settings.cache_clear()
+    monkeypatch.setenv("YDC_API_KEY", "")
+
+    from metasearchmcp.providers.youcom import YouComProvider
+
+    provider = YouComProvider()
+    assert provider.is_available() is False
+
+    get_settings.cache_clear()
+    monkeypatch.setenv("YDC_API_KEY", "test-key")
+    provider = YouComProvider()
+    assert provider.is_available() is True
+    get_settings.cache_clear()


### PR DESCRIPTION
## Why

MetaSearchMCP already has a clean provider registry for optional web backends. Adding You.com gives users another hosted search option that fits the same normalized provider contract without changing default behavior.

I kept this optional and followed the existing provider pattern.

## What changed

- added a new `youcom` provider backed by the You.com Search API
- registered it in the provider registry
- added `YDC_API_KEY` config and `.env.example` documentation
- documented explicit provider usage in the README
- added focused parser and availability tests

## Setup

```bash
export YDC_API_KEY=your-key-here
```

## Usage example

```bash
curl -X POST http://localhost:8000/search \
  -H "Content-Type: application/json" \
  -d '{
    "query": "playwright locator best practices",
    "providers": ["youcom"],
    "params": {"num_results": 5}
  }'
```

## Validation

- `uv sync --python 3.11 --extra dev`
- `uv run --python 3.11 ruff check metasearchmcp/providers/youcom.py metasearchmcp/providers/registry.py tests/test_youcom_provider.py`
- `uv run --python 3.11 pytest tests/test_youcom_provider.py tests/test_config_and_cli.py tests/test_broker_and_routes.py tests/test_providers.py tests/test_new_providers.py`

I also checked that the provider stays unavailable when `YDC_API_KEY` is unset, so existing default behavior is unchanged.

## Fallback / error handling

- missing `YDC_API_KEY` keeps the provider out of the enabled registry
- HTTP failures from You.com raise through the existing provider execution path
- other providers continue to work unchanged

## Tracking

- https://github.com/youdotcom-oss/integration-tracking/issues/85
